### PR TITLE
chore: add `api_key` arg for latest doc

### DIFF
--- a/searx/engines/openalex.py
+++ b/searx/engines/openalex.py
@@ -119,6 +119,7 @@ search_url = "https://api.openalex.org/works"
 # engines: - name: openalex; engine: openalex; mailto: "[email protected]"
 mailto = ""
 
+api_key = ""
 
 def request(query: str, params: "OnlineParams") -> None:
     # Build OpenAlex query using search parameter and paging
@@ -145,6 +146,9 @@ def request(query: str, params: "OnlineParams") -> None:
     # include mailto if configured for polite pool (engine module setting)
     if isinstance(mailto, str) and mailto != "":
         args["mailto"] = mailto
+
+    if isinstance(api_key, str) and api_key != "":
+        args["api_key"] = api_key
 
     params["url"] = f"{search_url}?{urlencode(args)}"
 

--- a/searx/engines/openalex.py
+++ b/searx/engines/openalex.py
@@ -17,7 +17,7 @@ Key features
   (reconstructed from inverted index), journal/venue, publisher, DOI, tags
   (concepts), PDF/HTML links, pages, volume, issue, published date, and a short
   citations comment
-- Supports OpenAlex "polite pool" by adding a ``mailto`` parameter
+- Supports OpenAlex "polite pool" by adding a ``api_key`` parameter
 
 
 Configuration
@@ -33,12 +33,12 @@ Minimal example for :origin:`settings.yml <searx/settings.yml>`:
      categories: science, scientific publications
      timeout: 5.0
      # Recommended by OpenAlex: join the polite pool with an email address
-     mailto: "[email protected]"
+     api_key: "[email protected]"
 
 Notes
 -----
 
-- The ``mailto`` key is optional but recommended by OpenAlex for better service.
+- The ``api_key`` key is optional but recommended by OpenAlex for better service.
 - Language is inherited from the user's UI language; when it is not ``all``, the
   engine adds ``filter=language:<iso2>`` (e.g. ``language:fr``). If OpenAlex has
   few results for that language, you may see fewer items.
@@ -69,7 +69,7 @@ Rate limits & polite pool
 
 OpenAlex offers a free public API with generous daily limits. For extra courtesy
 and improved service quality, include a contact email in each request via
-``mailto``. You can set it directly in the engine configuration as shown above.
+``api_key``. You can set it directly in the engine configuration as shown above.
 See: `OpenAlex API overview`_.
 
 
@@ -116,10 +116,9 @@ paging = True
 search_url = "https://api.openalex.org/works"
 
 # Optional: include your email for OpenAlex polite pool. Can be set from settings.yml
-# engines: - name: openalex; engine: openalex; mailto: "[email protected]"
-mailto = ""
-
+# engines: - name: openalex; engine: openalex; api_key: "[email protected]"
 api_key = ""
+
 
 def request(query: str, params: "OnlineParams") -> None:
     # Build OpenAlex query using search parameter and paging
@@ -143,10 +142,7 @@ def request(query: str, params: "OnlineParams") -> None:
     if filters:
         args["filter"] = ",".join(filters)
 
-    # include mailto if configured for polite pool (engine module setting)
-    if isinstance(mailto, str) and mailto != "":
-        args["mailto"] = mailto
-
+    # include api_key if configured for polite pool (engine module setting)
     if isinstance(api_key, str) and api_key != "":
         args["api_key"] = api_key
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [ ] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

## Summary by Sourcery

新功能：
- 允许 OpenAlex 引擎接受可选的 `api_key` 配置，并将其传递给发送到 OpenAlex 的请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow the OpenAlex engine to accept an optional api_key configuration and pass it through to OpenAlex requests.

</details>