### PR TITLE
feat: add httpx_curl_cffi transport support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ python-dateutil==2.9.0.post0
 pyyaml==6.0.3
 httpx[http2]==0.28.1
 httpx-socks[asyncio]==0.10.0
+httpx_curl_cffi>=0.1.5
 sniffio==1.3.1
 valkey==6.1.1
 markdown-it-py==4.2.0

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -47,6 +47,9 @@ ENGINE_DEFAULT_ARGS: dict[str, t.Any] = {
     "disabled": False,
     "inactive": False,
     "about": EngineAbout(),
+    # When True, skip stripping the User-Agent header in impersonate mode.
+    # Engines that set a custom UA (e.g. Google's gen_gsa_useragent) need this.
+    "keep_user_agent": False,
     "using_tor_proxy": False,
     "send_accept_language_header": True,
     "tokens": [],

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -59,6 +59,8 @@ max_page = 50
 time_range_support = True
 language_support = True
 safesearch = True
+# Google requires the GSA User-Agent set in request(); impersonate must not strip it.
+keep_user_agent = True
 
 time_range_dict = {"day": "d", "week": "w", "month": "m", "year": "y"}
 

--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -14,7 +14,18 @@ import httpx
 from httpx_socks import AsyncProxyTransport
 from python_socks import parse_proxy_url, ProxyConnectionError, ProxyTimeoutError, ProxyError
 
-from searx import logger
+from searx import logger, get_setting
+
+try:
+    from httpx_curl_cffi import AsyncCurlTransport, CurlOpt
+    from curl_cffi.const import CurlHttpVersion
+
+    HAS_CURL_CFFI = True
+except ImportError:
+    HAS_CURL_CFFI = False
+    AsyncCurlTransport = None  # type: ignore
+    CurlOpt = None  # type: ignore
+    CurlHttpVersion = None  # type: ignore
 
 CertTypes = str | tuple[str, str] | tuple[str, str, str]
 SslContextKeyType = tuple[str | None, CertTypes | None, bool, bool]
@@ -112,7 +123,7 @@ class AsyncProxyTransportFixed(AsyncProxyTransport):
 
 
 def get_transport_for_socks_proxy(
-    verify: bool, http2: bool, local_address: str, proxy_url: str, limit: httpx.Limits, retries: int
+    verify: bool, http2: bool, local_address: str | None, proxy_url: str, limit: httpx.Limits, retries: int
 ):
     # support socks5h (requests compatibility):
     # https://requests.readthedocs.io/en/master/user/advanced/#socks
@@ -143,8 +154,46 @@ def get_transport_for_socks_proxy(
 
 
 def get_transport(
-    verify: bool, http2: bool, local_address: str, proxy_url: str | None, limit: httpx.Limits, retries: int
+    verify: bool,
+    http2: bool,
+    local_address: str | None,
+    proxy_url: str | None,
+    limit: httpx.Limits,
+    retries: int,
+    impersonate: str | None = None,
 ):
+    if impersonate and HAS_CURL_CFFI:
+        # Use curl_cffi transport for browser TLS fingerprint impersonation.
+        # curl_cffi manages TLS internally (BoringSSL/NSS), so SSLContext and
+        # cipher shuffling are bypassed entirely.
+        _http_version = CurlHttpVersion.V3 if http2 else CurlHttpVersion.V1_1
+        logger.debug(
+            "using curl_cffi transport impersonating %s (proxy=%s, http_version=%s)",
+            impersonate,
+            proxy_url,
+            _http_version,
+        )
+        return AsyncCurlTransport(
+            impersonate=impersonate,
+            verify=verify,
+            proxy=proxy_url,
+            http_version=_http_version,
+            default_headers=True,
+            local_address=local_address,
+            debug=get_setting("general.debug"),
+            # FRESH_CONNECT avoids connection reuse issues in async parallel
+            # requests by giving each request a fresh curl handle.
+            curl_options={CurlOpt.FRESH_CONNECT: True},
+        )
+
+    if impersonate and not HAS_CURL_CFFI:
+        logger.warning(
+            "impersonate is set to '%s' but httpx_curl_cffi is not installed. "
+            "Falling back to standard httpx transport. "
+            "Install it with: pip install httpx_curl_cffi",
+            impersonate,
+        )
+
     _verify = get_sslcontexts(None, None, verify, True) if verify is True else verify
     return httpx.AsyncHTTPTransport(
         # pylint: disable=protected-access
@@ -166,10 +215,11 @@ def new_client(
     max_keepalive_connections: int,
     keepalive_expiry: float,
     proxies: dict[str, str],
-    local_address: str,
+    local_address: str | None,
     retries: int,
     max_redirects: int,
     hook_log_response: t.Callable[..., t.Any] | None,
+    impersonate: str | None = None,
 ) -> httpx.AsyncClient:
     limit = httpx.Limits(
         max_connections=max_connections,
@@ -182,7 +232,22 @@ def new_client(
     for pattern, proxy_url in proxies.items():
         if not enable_http and pattern.startswith('http://'):
             continue
-        if proxy_url.startswith('socks4://') or proxy_url.startswith('socks5://') or proxy_url.startswith('socks5h://'):
+        if impersonate and HAS_CURL_CFFI:
+            # curl_cffi (libcurl) natively supports http, https, socks4,
+            # socks5 and socks5h proxies, so route ALL proxy types through
+            # AsyncCurlTransport when impersonation is enabled.
+            mounts[pattern] = get_transport(
+                verify,
+                enable_http2,
+                local_address,
+                proxy_url,
+                limit,
+                retries,
+                impersonate=impersonate,
+            )
+        elif (
+            proxy_url.startswith('socks4://') or proxy_url.startswith('socks5://') or proxy_url.startswith('socks5h://')
+        ):
             mounts[pattern] = get_transport_for_socks_proxy(
                 verify, enable_http2, local_address, proxy_url, limit, retries
             )
@@ -192,7 +257,15 @@ def new_client(
     if not enable_http:
         mounts['http://'] = AsyncHTTPTransportNoHttp()
 
-    transport = get_transport(verify, enable_http2, local_address, None, limit, retries)
+    transport = get_transport(
+        verify,
+        enable_http2,
+        local_address,
+        None,
+        limit,
+        retries,
+        impersonate=impersonate,
+    )
 
     event_hooks = None
     if hook_log_response:

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -15,7 +15,7 @@ from itertools import cycle
 
 import httpx
 
-from searx import logger, sxng_debug
+from searx import logger, sxng_debug, get_setting
 from searx.extended_types import SXNG_Response
 from .client import new_client, get_loop, AsyncHTTPTransportNoHttp
 from .raise_for_httperror import raise_for_httperror
@@ -57,6 +57,8 @@ class Network:
         'max_redirects',
         'retries',
         'retry_on_http_error',
+        'impersonate',
+        'keep_user_agent',
         '_local_addresses_cycle',
         '_proxies_cycle',
         '_clients',
@@ -66,7 +68,7 @@ class Network:
     _TOR_CHECK_RESULT = {}
 
     def __init__(
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         enable_http: bool = True,
         verify: bool = True,
@@ -81,6 +83,8 @@ class Network:
         retry_on_http_error: bool = False,
         max_redirects: int = 30,
         logger_name: str = None,  # pyright: ignore[reportArgumentType]
+        impersonate: str | None = None,
+        keep_user_agent: bool = False,
     ):
 
         self.enable_http = enable_http
@@ -95,6 +99,8 @@ class Network:
         self.retries = retries
         self.retry_on_http_error = retry_on_http_error
         self.max_redirects = max_redirects
+        self.impersonate = impersonate
+        self.keep_user_agent = keep_user_agent
         self._local_addresses_cycle = self.get_ipaddress_cycle()
         self._proxies_cycle = self.get_proxy_cycles()
         self._clients = {}
@@ -190,9 +196,9 @@ class Network:
     async def get_client(self, verify: bool | None = None, max_redirects: int | None = None) -> httpx.AsyncClient:
         verify = self.verify if verify is None else verify
         max_redirects = self.max_redirects if max_redirects is None else max_redirects
-        local_address = next(self._local_addresses_cycle)
+        local_address: str | None = next(self._local_addresses_cycle)
         proxies = next(self._proxies_cycle)  # is a tuple so it can be part of the key
-        key = (verify, max_redirects, local_address, proxies)
+        key = (verify, max_redirects, local_address, proxies, self.impersonate, self.keep_user_agent)
         hook_log_response = self.log_response if sxng_debug else None
         if key not in self._clients or self._clients[key].is_closed:
             client = new_client(
@@ -207,6 +213,7 @@ class Network:
                 0,
                 max_redirects,
                 hook_log_response,
+                impersonate=self.impersonate,
             )
             if self.using_tor_proxy and not await self.check_tor_proxy(client, proxies):
                 await client.aclose()
@@ -274,9 +281,22 @@ class Network:
         was_disconnected = False
         do_raise_for_httperror = Network.extract_do_raise_for_httperror(kwargs)
         kwargs_clients = Network.extract_kwargs_clients(kwargs)
+
+        cookies = kwargs.pop("cookies", None)
+
+        if self.impersonate and not self.keep_user_agent:
+            # In impersonate mode, prevent the application's User-Agent from
+            # overwriting the impersonated browser's default User-Agent.
+            # Normalize header keys to lowercase first so pop("user-agent")
+            # matches regardless of the original casing.
+            # Engines with keep_user_agent=True (e.g. Google) set their own
+            # required UA and skip this stripping.
+            # See https://curl-cffi.readthedocs.io/en/latest/api.html#curl_cffi.Curl.impersonate
+            kwargs["headers"] = {k.lower(): v for k, v in kwargs.get("headers", {}).items()}
+            kwargs["headers"].pop("user-agent", None)
+
         while retries >= 0:  # pragma: no cover
             client = await self.get_client(**kwargs_clients)
-            cookies = kwargs.pop("cookies", None)
             client.cookies = httpx.Cookies(cookies)
             try:
                 if stream:
@@ -333,9 +353,30 @@ def check_network_configuration():
         raise RuntimeError("Invalid network configuration")
 
 
+def get_default_network_params() -> dict[str, t.Any]:
+    """Return default parameters for :py:obj:`Network` from the ``outgoing`` settings."""
+    # see https://github.com/encode/httpx/blob/e05a5372eb6172287458b37447c30f650047e1b8/httpx/_transports/default.py#L108-L121  # pylint: disable=line-too-long
+    s: dict[str, t.Any] = get_setting("outgoing")
+    return {
+        'enable_http': False,
+        'verify': s['verify'],
+        'enable_http2': s['enable_http2'],
+        'max_connections': s['pool_connections'],
+        'max_keepalive_connections': s['pool_maxsize'],
+        'keepalive_expiry': s['keepalive_expiry'],
+        'local_addresses': s['source_ips'],
+        'using_tor_proxy': s['using_tor_proxy'],
+        'proxies': s['proxies'],
+        'max_redirects': s['max_redirects'],
+        'retries': s['retries'],
+        'retry_on_http_error': False,
+        'impersonate': s.get('impersonate'),
+        'keep_user_agent': False,
+    }
+
+
 def initialize(
     settings_engines: list[dict[str, t.Any]] = None,  # pyright: ignore[reportArgumentType]
-    settings_outgoing: dict[str, t.Any] = None,  # pyright: ignore[reportArgumentType]
 ) -> None:
     # pylint: disable=import-outside-toplevel)
     from searx.engines import engines
@@ -344,30 +385,13 @@ def initialize(
     # pylint: enable=import-outside-toplevel)
 
     settings_engines = settings_engines or settings['engines']
-    settings_outgoing = settings_outgoing or settings['outgoing']
+    default_params = get_default_network_params()
 
-    # default parameters for AsyncHTTPTransport
-    # see https://github.com/encode/httpx/blob/e05a5372eb6172287458b37447c30f650047e1b8/httpx/_transports/default.py#L108-L121  # pylint: disable=line-too-long
-    default_params: dict[str, t.Any] = {
-        'enable_http': False,
-        'verify': settings_outgoing['verify'],
-        'enable_http2': settings_outgoing['enable_http2'],
-        'max_connections': settings_outgoing['pool_connections'],
-        'max_keepalive_connections': settings_outgoing['pool_maxsize'],
-        'keepalive_expiry': settings_outgoing['keepalive_expiry'],
-        'local_addresses': settings_outgoing['source_ips'],
-        'using_tor_proxy': settings_outgoing['using_tor_proxy'],
-        'proxies': settings_outgoing['proxies'],
-        'max_redirects': settings_outgoing['max_redirects'],
-        'retries': settings_outgoing['retries'],
-        'retry_on_http_error': False,
-    }
-
-    def new_network(params: dict[str, t.Any], logger_name: str | None = None):
+    def new_network(network_params: dict[str, t.Any], logger_name: str | None = None):
         nonlocal default_params
         result = {}
         result.update(default_params)  # pyright: ignore[reportUnknownMemberType]
-        result.update(params)  # pyright: ignore[reportUnknownMemberType]
+        result.update(network_params)  # pyright: ignore[reportUnknownMemberType]
         if logger_name:
             result['logger_name'] = logger_name
         return Network(**result)  # type: ignore
@@ -390,19 +414,19 @@ def initialize(
     NETWORKS['ipv6'] = new_network({'local_addresses': '::'}, logger_name='ipv6')
 
     # define networks from outgoing.networks
-    for network_name, network in settings_outgoing['networks'].items():
-        NETWORKS[network_name] = new_network(network, logger_name=network_name)
+    for network_name, network_params in get_setting("outgoing.networks").items():
+        NETWORKS[network_name] = new_network(network_params, logger_name=network_name)
 
     # define networks from engines.[i].network (except references)
     for engine_name, engine, network in iter_networks():
         if network is None:
-            network = {}
+            network_params: dict[str, t.Any] = {}
             for attribute_name, attribute_value in default_params.items():
                 if hasattr(engine, attribute_name):
-                    network[attribute_name] = getattr(engine, attribute_name)
+                    network_params[attribute_name] = getattr(engine, attribute_name)
                 else:
-                    network[attribute_name] = attribute_value
-            NETWORKS[engine_name] = new_network(network, logger_name=engine_name)
+                    network_params[attribute_name] = attribute_value
+            NETWORKS[engine_name] = new_network(network_params, logger_name=engine_name)
         elif isinstance(network, dict):
             NETWORKS[engine_name] = new_network(network, logger_name=engine_name)
 
@@ -415,7 +439,7 @@ def initialize(
     # same parameters than the default network, but HTTP/2 is disabled.
     # It decreases the CPU load average, and the total time is more or less the same
     if 'image_proxy' not in NETWORKS:
-        image_proxy_params = default_params.copy()
+        image_proxy_params = get_default_network_params()
         image_proxy_params['enable_http2'] = False
         NETWORKS['image_proxy'] = new_network(image_proxy_params, logger_name='image_proxy')
 

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -37,7 +37,7 @@ def initialize(
 ):
     settings_engines = settings_engines or settings['engines']
     load_engines(settings_engines)
-    initialize_network(settings_engines, settings['outgoing'])
+    initialize_network(settings_engines)
     if check_network:
         check_network_configuration()
     initialize_metrics([engine['name'] for engine in settings_engines], enable_metrics)

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -264,6 +264,12 @@ SCHEMA: dict[str, t.Any] = {
         # Tor configuration
         'using_tor_proxy': SettingsValue(bool, False),
         'extra_proxy_timeout': SettingsValue(int, 0),
+        # curl_cffi TLS fingerprint impersonation target.
+        # When set (e.g. "chrome", "firefox", "edge", "safari"), HTTPS requests are
+        # routed through curl_cffi instead of httpx.  HTTP/3 is enabled automatically
+        # when enable_http2 is True.  Requires: pip install httpx_curl_cffi
+        # See https://github.com/lexiforest/curl_cffi for the full list of targets.
+        'impersonate': SettingsValue((None, str), None),
         'networks': {},
     },
     'plugins': SettingsValue(dict, {}),

--- a/utils/compare_curl_cffi.py
+++ b/utils/compare_curl_cffi.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Compare TLS fingerprint with and without curl_cffi impersonation.
+
+Usage:
+  python utils/compare_curl_cffi.py                 # compare fingerprints
+  python utils/compare_curl_cffi.py --url https://example.com  # test specific URL
+  python utils/compare_curl_cffi.py --impersonate safari15_5   # use different browser
+"""
+
+import asyncio
+import json
+import sys
+import argparse
+
+import httpx
+
+FINGERPRINT_CHECK_URLS = [
+    "https://tls.peet.ws/api/all",  # JA3/JA4 + HTTP/2 fingerprints
+    "https://tools.scrapfly.io/api/fp/ja3",  # JA3 fingerprint + headers
+]
+
+
+def print_section(title: str):
+    print(f"\n{'='*60}")
+    print(f"  {title}")
+    print(f"{'='*60}")
+
+
+async def test_standard_httpx(url: str):
+    """Test with standard httpx transport (no impersonation)."""
+    print_section("Standard httpx (no impersonation)")
+
+    try:
+        async with httpx.AsyncClient(http2=True, timeout=15) as client:
+            resp = await client.get(url)
+            print(f"Status: {resp.status_code}")
+            print(f"HTTP Version: {resp.http_version}")
+            _print_json_response(resp)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+async def test_curl_cffi(url: str, impersonate: str):
+    """Test with curl_cffi transport (browser TLS fingerprint impersonation)."""
+    print_section(f"curl_cffi impersonating '{impersonate}'")
+
+    try:
+        from httpx_curl_cffi import AsyncCurlTransport, CurlOpt
+    except ImportError:
+        print("ERROR: httpx_curl_cffi is not installed. Run: pip install httpx_curl_cffi")
+        return
+
+    try:
+        transport = AsyncCurlTransport(
+            impersonate=impersonate,
+            verify=True,
+            curl_options={CurlOpt.FRESH_CONNECT: True},
+        )
+        async with httpx.AsyncClient(transport=transport, timeout=15) as client:
+            resp = await client.get(url)
+            print(f"Status: {resp.status_code}")
+            print(f"HTTP Version: {resp.http_version}")
+            _print_json_response(resp)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+async def test_curl_cffi_no_impersonation(url: str):
+    """Test with curl_cffi transport WITHOUT impersonation (raw curl fingerprint)."""
+    print_section("curl_cffi transport (NO impersonation)")
+
+    try:
+        from httpx_curl_cffi import AsyncCurlTransport, CurlOpt
+    except ImportError:
+        print("ERROR: httpx_curl_cffi is not installed. Run: pip install httpx_curl_cffi")
+        return
+
+    try:
+        transport = AsyncCurlTransport(
+            verify=True,
+            curl_options={CurlOpt.FRESH_CONNECT: True},
+        )
+        async with httpx.AsyncClient(transport=transport, timeout=15) as client:
+            resp = await client.get(url)
+            print(f"Status: {resp.status_code}")
+            print(f"HTTP Version: {resp.http_version}")
+            _print_json_response(resp)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def _print_json_response(resp: httpx.Response):
+    """Pretty-print JSON response, focusing on fingerprint-related fields."""
+    try:
+        data = resp.json()
+    except Exception:
+        # Not JSON, print first 500 chars of text
+        print(resp.text[:500])
+        return
+
+    # Extract key fingerprint fields for comparison
+    _extract_and_print(data, "ja3", "JA3 Fingerprint")
+    _extract_and_print(data, "ja3_hash", "JA3 Hash")
+    _extract_and_print(data, "ja4", "JA4 Fingerprint")
+    _extract_and_print(data, "akamai", "Akamai Fingerprint")
+    _extract_and_print(data, "peetprint", "PeetPrint (HTTP/2)")
+    _extract_and_print(data, "http_version", "HTTP Version")
+    _extract_and_print(data, "tls", "TLS Info")
+    _extract_and_print(data, "user_agent", "User-Agent")
+
+    # Fallback: print the whole response
+    if not any(k in str(data).lower() for k in ["ja3", "ja4", "tls"]):
+        print(json.dumps(data, indent=2)[:2000])
+
+
+def _extract_and_print(data, key: str, label: str):
+    """Extract and print a specific key from the response data."""
+    if isinstance(data, dict):
+        if key in data:
+            value = data[key]
+            if isinstance(value, (dict, list)):
+                print(f"\n{label}:")
+                print(json.dumps(value, indent=2))
+            else:
+                print(f"{label}: {value}")
+    elif isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict) and key in item:
+                print(f"{label}: {item[key]}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Compare TLS fingerprints with and without curl_cffi impersonation")
+    parser.add_argument(
+        "--url",
+        default=None,
+        help="URL to test (default: use fingerprint-checking endpoints)",
+    )
+    parser.add_argument(
+        "--impersonate",
+        default="chrome",
+        help="Browser fingerprint to impersonate (default: chrome)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Test all built-in fingerprint check URLs",
+    )
+    args = parser.parse_args()
+
+    urls = [args.url] if args.url else FINGERPRINT_CHECK_URLS
+
+    for url in urls:
+        print(f"\n{'#'*60}")
+        print(f"  Target: {url}")
+        print(f"{'#'*60}")
+
+        # Test 1: Standard httpx (no curl_cffi)
+        await test_standard_httpx(url)
+
+        # Test 2: curl_cffi without impersonation (raw curl fingerprint)
+        await test_curl_cffi_no_impersonation(url)
+
+        # Test 3: curl_cffi with browser impersonation
+        await test_curl_cffi(url, args.impersonate)
+
+        if not args.all:
+            break
+
+    print_section("Summary")
+    print("""
+Key comparison points:
+  1. JA3/JA4 hash: should differ between standard httpx and curl_cffi
+  2. curl_cffi with impersonation: JA3 should match a real browser
+  3. HTTP/2 fingerprint (PeetPrint/Akamai): curl_cffi mimics real browser H2 settings
+
+If JA3 hashes are different between the three tests, curl_cffi is working correctly.
+If JA3 is the same between tests 1 & 2, curl_cffi's transport is active but not impersonating.
+""")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
…sonation

Add optional curl_cffi_impersonate setting to reduce bot detection by impersonating browser TLS/JA3/JA4 and HTTP/2 fingerprints via curl_cffi.

- settings: add outgoing.curl_cffi_impersonate (None, str) default None
- network: add curl_cffi_impersonate to Network class and initialize()
- client: use AsyncCurlTransport when curl_cffi_impersonate is set
- All proxy types (http, https, socks4, socks5, socks5h) work with curl_cffi
- Falls back gracefully if httpx_curl_cffi is not installed
- Includes compare_curl_cffi.py test script to verify TLS fingerprint changes

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [ ] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

## Summary by Sourcery

添加可选的基于 curl_cffi 的 HTTP 传输层，支持浏览器指纹伪装和 HTTP/3，通过网络设置和客户端创建进行串联，并提供对比 TLS 指纹的工具。

New Features:
- 引入 `curl_cffi_impersonate` 设置，用于在出站请求中启用基于 `httpx_curl_cffi` 的类浏览器 TLS/HTTP 指纹伪装。
- 当启用 curl_cffi 伪装且可用 `httpx_curl_cffi` 时，为出站请求提供 HTTP/3（QUIC）支持。

Enhancements:
- 扩展网络配置和异步客户端创建逻辑，传递 `curl_cffi_impersonate` 和 `enable_http3` 选项，并据此缓存客户端。
- 当启用伪装时，将所有代理类型都通过 curl_cffi 传输层路由；当 `httpx_curl_cffi` 或 HTTP/3 不可用时，提供优雅降级与日志记录。

Build:
- 在 `requirements.txt` 中添加 `httpx_curl_cffi` 作为运行时依赖。

Documentation:
- 在默认设置中文档化 `curl_cffi_impersonate` 和 `enable_http3` 选项，包括支持的伪装目标。

Tests:
- 添加 `compare_curl_cffi.py` 工具，用于对比启用和未启用 curl_cffi 伪装时的 TLS 指纹，以进行验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional curl_cffi-based HTTP transport with browser fingerprint impersonation and HTTP/3 support, wired through network settings and client creation, with tooling to compare TLS fingerprints.

New Features:
- Introduce curl_cffi_impersonate setting to enable httpx_curl_cffi-based browser-like TLS/HTTP fingerprint impersonation in outgoing requests.
- Support HTTP/3 (QUIC) for outgoing requests when curl_cffi impersonation is enabled and httpx_curl_cffi is available.

Enhancements:
- Extend Network configuration and async client creation to pass curl_cffi_impersonate and enable_http3 options and to cache clients accordingly.
- Route all proxy types through the curl_cffi transport when impersonation is enabled, with graceful fallback and logging when httpx_curl_cffi or HTTP/3 is unavailable.

Build:
- Add httpx_curl_cffi as a runtime dependency in requirements.txt.

Documentation:
- Document curl_cffi_impersonate and enable_http3 options in the default settings, including supported impersonation targets.

Tests:
- Add compare_curl_cffi.py utility to compare TLS fingerprints with and without curl_cffi impersonation for verification.

</details>

新功能：
- 引入 `curl_cffi_impersonate` 设置，通过 `httpx_curl_cffi` 启用类似浏览器的 TLS/HTTP 指纹伪装。
- 在启用伪装时，支持通过 `AsyncCurlTransport` 路由所有代理类型。

增强：
- 扩展 Network 和客户端创建逻辑，以传递 `curl_cffi_impersonate` 配置并相应地缓存客户端。
- 当 `httpx_curl_cffi` 不可用时，优雅地回退到标准的 httpx 传输。

构建：
- 在 `requirements.txt` 中添加 `httpx_curl_cffi` 作为依赖。

文档：
- 在默认设置中添加配置注释，记录支持的 curl_cffi 伪装目标。

测试：
- 添加 `compare_curl_cffi.py` 工具脚本，用于比较启用和未启用 curl_cffi 伪装时的 TLS 指纹。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可选的基于 curl_cffi 的 HTTP 传输层，支持浏览器指纹伪装和 HTTP/3，通过网络设置和客户端创建进行串联，并提供对比 TLS 指纹的工具。

New Features:
- 引入 `curl_cffi_impersonate` 设置，用于在出站请求中启用基于 `httpx_curl_cffi` 的类浏览器 TLS/HTTP 指纹伪装。
- 当启用 curl_cffi 伪装且可用 `httpx_curl_cffi` 时，为出站请求提供 HTTP/3（QUIC）支持。

Enhancements:
- 扩展网络配置和异步客户端创建逻辑，传递 `curl_cffi_impersonate` 和 `enable_http3` 选项，并据此缓存客户端。
- 当启用伪装时，将所有代理类型都通过 curl_cffi 传输层路由；当 `httpx_curl_cffi` 或 HTTP/3 不可用时，提供优雅降级与日志记录。

Build:
- 在 `requirements.txt` 中添加 `httpx_curl_cffi` 作为运行时依赖。

Documentation:
- 在默认设置中文档化 `curl_cffi_impersonate` 和 `enable_http3` 选项，包括支持的伪装目标。

Tests:
- 添加 `compare_curl_cffi.py` 工具，用于对比启用和未启用 curl_cffi 伪装时的 TLS 指纹，以进行验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional curl_cffi-based HTTP transport with browser fingerprint impersonation and HTTP/3 support, wired through network settings and client creation, with tooling to compare TLS fingerprints.

New Features:
- Introduce curl_cffi_impersonate setting to enable httpx_curl_cffi-based browser-like TLS/HTTP fingerprint impersonation in outgoing requests.
- Support HTTP/3 (QUIC) for outgoing requests when curl_cffi impersonation is enabled and httpx_curl_cffi is available.

Enhancements:
- Extend Network configuration and async client creation to pass curl_cffi_impersonate and enable_http3 options and to cache clients accordingly.
- Route all proxy types through the curl_cffi transport when impersonation is enabled, with graceful fallback and logging when httpx_curl_cffi or HTTP/3 is unavailable.

Build:
- Add httpx_curl_cffi as a runtime dependency in requirements.txt.

Documentation:
- Document curl_cffi_impersonate and enable_http3 options in the default settings, including supported impersonation targets.

Tests:
- Add compare_curl_cffi.py utility to compare TLS fingerprints with and without curl_cffi impersonation for verification.

</details>

</details>