### PR TITLE
feat: add Toutiao (字节跳动) engine (General, news, video, image)

### DIFF
--- a/searx/engines/toutiao.py
+++ b/searx/engines/toutiao.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Toutiao_ (头条搜索) is a Chinese search engine by ByteDance.
+
+.. _Toutiao: https://so.toutiao.com
+
+Supported categories (via ``toutiao_categ``):
+  - ``search`` — general web search
+  - ``news`` — news search
+  - ``video`` — video search
+  - ``images`` — image search
+"""
+
+import json
+import re
+import time
+from datetime import datetime
+from urllib.parse import urlencode
+
+from searx.result_types import EngineResults
+
+about = {
+    "website": "https://so.toutiao.com",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "HTML",
+}
+
+categories = []
+paging = True
+time_range_support = True
+time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
+
+base_url = "https://so.toutiao.com/search"
+
+toutiao_categ = "search"
+"""Supported categories: "search", "news", "video", "images"."""
+
+# regex to extract JSON payloads from <script type="application/json"> tags
+_JSON_SCRIPT_RE = re.compile(r'<script[^>]*type="application/json"[^>]*>(.*?)</script>', re.DOTALL)
+# strip HTML tags from highlighted text
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def init(_):
+    if toutiao_categ not in ("search", "news", "video", "images"):
+        raise ValueError("invalid toutiao category: %s" % toutiao_categ)
+
+
+def _parse_datetime(dt_str: str):
+    """Parse a datetime string like '2026-06-12 06:21:52'."""
+    if not dt_str:
+        return None
+    try:
+        return datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def _extract_text(obj):
+    """If *obj* is a dict with a ``text`` key, return that; otherwise return
+    *obj* as-is (or empty string)."""
+    if isinstance(obj, dict):
+        return obj.get("text", "")
+    return obj or ""
+
+
+def _strip_html(text: str) -> str:
+    """Remove HTML tags from *text*."""
+    if not text:
+        return ""
+    return _HTML_TAG_RE.sub("", text)
+
+
+def _get_metadata(data: dict) -> str:
+    """Extract source/metadata from a result dict, preferring clean fields
+    over highlighted ones."""
+    metadata = data.get("media_name") or data.get("source") or ""
+    if not metadata:
+        emphasized = data.get("emphasized")
+        if isinstance(emphasized, dict):
+            metadata = _strip_html(emphasized.get("source", ""))
+    return metadata
+
+
+def _get_thumbnail(data: dict) -> str:
+    """Extract thumbnail URL from a result dict."""
+    image_list = data.get("image_list")
+    if image_list and isinstance(image_list, list):
+        return image_list[0].get("url", "")
+    return data.get("image_url", "")
+
+
+# ----------------------------------------------------------------------------
+# URL builders per category
+# ----------------------------------------------------------------------------
+
+
+def _search_url(query: str, page_num: int, time_range: str = "") -> str:
+    args = {
+        "dvpf": "pc",
+        "keyword": query,
+        "page_num": page_num,
+    }
+    if time_range and time_range in time_range_dict:
+        now = int(time.time())
+        past = now - time_range_dict[time_range]
+        args["filter_period"] = time_range
+        args["min_time"] = past
+        args["max_time"] = now
+    return f"{base_url}?{urlencode(args)}"
+
+
+def _news_url(query: str, page_num: int) -> str:
+    args = {
+        "dvpf": "pc",
+        "from": "news",
+        "keyword": query,
+        "page_num": page_num,
+    }
+    return f"{base_url}?{urlencode(args)}"
+
+
+def _video_url(query: str, page_num: int) -> str:
+    args = {
+        "dvpf": "pc",
+        "from": "video",
+        "pd": "video",
+        "search_id": "",
+        "keyword": query,
+        "page_num": page_num,
+    }
+    return f"{base_url}?{urlencode(args)}"
+
+
+def _images_url(query: str, page_num: int) -> str:
+    args = {
+        "dvpf": "pc",
+        "from": "gallery",
+        "pd": "atlas",
+        "search_id": "",
+        "keyword": query,
+        "page_num": page_num,
+    }
+    return f"{base_url}?{urlencode(args)}"
+
+
+_URL_BUILDERS = {
+    "search": _search_url,
+    "news": _news_url,
+    "video": _video_url,
+    "images": _images_url,
+}
+
+
+def request(query: str, params) -> None:
+    page_num = params["pageno"] - 1
+    time_range = params.get("time_range", "")
+    if toutiao_categ == "search" and time_range:
+        params["url"] = _search_url(query, page_num, time_range)
+    else:
+        params["url"] = _URL_BUILDERS[toutiao_categ](query, page_num)
+
+
+# ----------------------------------------------------------------------------
+# Response parsers per category
+# ----------------------------------------------------------------------------
+
+
+def _parse_web_card(res: EngineResults, data: dict):
+    """Parse a regular web / news result (``undefined-default`` template)."""
+    url = data.get("open_url") or data.get("source_url") or ""
+    title = data.get("title", "")
+    content = data.get("abstract", "")
+    thumbnail = _get_thumbnail(data)
+    metadata = _get_metadata(data)
+    publishedDate = _parse_datetime(data.get("datetime", ""))
+
+    res.add(
+        res.types.MainResult(
+            url=url,
+            title=title,
+            content=content,
+            thumbnail=thumbnail,
+            metadata=metadata,
+            publishedDate=publishedDate,
+        )
+    )
+
+
+def _parse_video_card(res: EngineResults, data: dict, template: str = "videos.html"):
+    """Parse a video result (``video-undefined-default`` or similar)."""
+    url = data.get("open_url") or data.get("source_url") or ""
+    title = data.get("title", "")
+    content = data.get("abstract", "")
+    thumbnail = _get_thumbnail(data)
+    metadata = _get_metadata(data)
+    publishedDate = _parse_datetime(data.get("datetime", ""))
+    length_str = data.get("video_duration_str", "")
+
+    # Try to parse duration string like "01:10:05" to seconds
+    length = None
+    if length_str:
+        parts = length_str.split(":")
+        try:
+            if len(parts) == 3:
+                length = int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+            elif len(parts) == 2:
+                length = int(parts[0]) * 60 + int(parts[1])
+        except (ValueError, IndexError):
+            pass
+
+    res.add(
+        res.types.MainResult(
+            template=template,
+            url=url,
+            title=title,
+            content=content,
+            thumbnail=thumbnail,
+            metadata=metadata,
+            publishedDate=publishedDate,
+            length=length,
+        )
+    )
+
+
+def _parse_external_video_card(res: EngineResults, data: dict):
+    """Parse an external video embed (``video-67-video``, Bilibili etc.)."""
+    display = data.get("display", {})
+    title = _extract_text(display.get("title", ""))
+    url = data.get("url", "")
+    if not url:
+        info = display.get("info", {})
+        if isinstance(info, dict):
+            url = info.get("url", "")
+
+    if url:
+        res.add(
+            res.types.MainResult(
+                template="videos.html",
+                url=url,
+                title=title,
+                content="",
+            )
+        )
+
+
+def _parse_general_or_news(res: EngineResults, json_blobs: list[dict]):
+    """Parse general search / news results."""
+    for data in json_blobs:
+        if "data" not in data:
+            continue
+        d = data["data"]
+        template_key = d.get("template_key", "")
+
+        if template_key == "undefined-default":
+            _parse_web_card(res, d)
+
+        elif "homepage" in template_key or "toutiao_web" in template_key or "baike" in template_key:
+            display = d.get("display", {})
+            title = _extract_text(display.get("title", ""))
+            url = d.get("url", "")
+            if not url:
+                info = display.get("info", {})
+                if isinstance(info, dict):
+                    url = info.get("url", "")
+            content = ""
+            summary = display.get("summary")
+            if isinstance(summary, dict):
+                content = summary.get("text", "")
+            if url:
+                res.add(res.types.MainResult(url=url, title=title, content=content))
+
+        elif "video" in template_key:
+            display = d.get("display", [])
+            if isinstance(display, list):
+                for item in display:
+                    _parse_video_card(res, item)
+            elif isinstance(display, dict):
+                # external video embed card
+                _parse_external_video_card(res, d)
+
+
+def _parse_video_tab(res: EngineResults, json_blobs: list[dict]):
+    """Parse dedicated video tab results."""
+    for data in json_blobs:
+        if "data" not in data:
+            continue
+        d = data["data"]
+        template_key = d.get("template_key", "")
+
+        if template_key == "video-undefined-default":
+            _parse_video_card(res, d)
+
+        elif template_key == "video-67-video":
+            _parse_external_video_card(res, d)
+
+
+def _parse_images(res: EngineResults, json_blobs: list[dict]):
+    """Parse image search results (``rawData.data``)."""
+    for data in json_blobs:
+        if "rawData" not in data:
+            continue
+        rd = data["rawData"]
+        items = rd.get("data")
+        if not isinstance(items, list):
+            continue
+
+        for item in items:
+            img_url = item.get("img_url") or ""
+            thumbnail_src = item.get("img_small_url") or img_url
+            source_url = item.get("original_page_url") or ""
+            title = item.get("text") or ""
+
+            height = item.get("height", 0)
+            width = item.get("width", 0)
+            resolution = ""
+            if width and height:
+                resolution = f"{width}x{height}"
+
+            res.add(
+                res.types.Image(
+                    url=source_url or img_url,
+                    title=title,
+                    img_src=img_url,
+                    thumbnail_src=thumbnail_src,
+                    resolution=resolution,
+                )
+            )
+
+
+_RESPONSE_PARSERS = {
+    "search": _parse_general_or_news,
+    "news": _parse_general_or_news,
+    "video": _parse_video_tab,
+    "images": _parse_images,
+}
+
+
+def response(resp) -> EngineResults:
+    res = EngineResults()
+
+    json_blobs = []
+    for match in _JSON_SCRIPT_RE.finditer(resp.text):
+        try:
+            json_blobs.append(json.loads(match.group(1)))
+        except json.JSONDecodeError:
+            continue
+
+    _RESPONSE_PARSERS[toutiao_categ](res, json_blobs)
+    return res

--- a/searx/engines/toutiao.py
+++ b/searx/engines/toutiao.py
@@ -28,8 +28,8 @@ about = {
 
 categories = []
 paging = True
-time_range_support = True
-time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
+# time_range_support = True
+# time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
 
 base_url = "https://so.toutiao.com/search"
 
@@ -102,12 +102,12 @@ def _search_url(query: str, page_num: int, time_range: str = "") -> str:
         "keyword": query,
         "page_num": page_num,
     }
-    if time_range and time_range in time_range_dict:
-        now = int(time.time())
-        past = now - time_range_dict[time_range]
-        args["filter_period"] = time_range
-        args["min_time"] = past
-        args["max_time"] = now
+    # if time_range and time_range in time_range_dict:
+    #     now = int(time.time())
+    #     past = now - time_range_dict[time_range]
+    #     args["filter_period"] = time_range
+    #     args["min_time"] = past
+    #     args["max_time"] = now
     return f"{base_url}?{urlencode(args)}"
 
 

--- a/searx/engines/toutiao.py
+++ b/searx/engines/toutiao.py
@@ -28,8 +28,8 @@ about = {
 
 categories = []
 paging = True
-# time_range_support = True
-# time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
+time_range_support = True
+time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}
 
 base_url = "https://so.toutiao.com/search"
 
@@ -99,15 +99,17 @@ def _get_thumbnail(data: dict) -> str:
 def _search_url(query: str, page_num: int, time_range: str = "") -> str:
     args = {
         "dvpf": "pc",
+        "from": "search_tab",
+        "pd": "synthesis",
         "keyword": query,
         "page_num": page_num,
     }
-    # if time_range and time_range in time_range_dict:
-    #     now = int(time.time())
-    #     past = now - time_range_dict[time_range]
-    #     args["filter_period"] = time_range
-    #     args["min_time"] = past
-    #     args["max_time"] = now
+    if time_range and time_range in time_range_dict:
+        now = int(time.time())
+        past = now - time_range_dict[time_range]
+        args["filter_period"] = time_range
+        args["min_time"] = past
+        args["max_time"] = now
     return f"{base_url}?{urlencode(args)}"
 
 
@@ -115,6 +117,7 @@ def _news_url(query: str, page_num: int) -> str:
     args = {
         "dvpf": "pc",
         "from": "news",
+        "pd": "information",
         "keyword": query,
         "page_num": page_num,
     }

--- a/searx/engines/toutiao.py
+++ b/searx/engines/toutiao.py
@@ -27,6 +27,7 @@ about = {
 }
 
 categories = []
+language = "zh"
 paging = True
 time_range_support = True
 time_range_dict = {"day": 86400, "week": 604800, "month": 2592000, "year": 31536000}

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -3135,6 +3135,34 @@ engines:
     base_url: https://search.infospace.com
     disabled: true
 
+  - name: toutiao
+    engine: toutiao
+    shortcut: tt
+    disabled: false
+    categories: general
+    toutiao_categ: search
+
+  - name: toutiao news
+    engine: toutiao
+    shortcut: ttn
+    disabled: false
+    categories: news
+    toutiao_categ: news
+
+  - name: toutiao images
+    engine: toutiao
+    shortcut: tti
+    disabled: false
+    categories: images
+    toutiao_categ: images
+
+  - name: toutiao videos
+    engine: toutiao
+    shortcut: ttv
+    disabled: false
+    categories: videos
+    toutiao_categ: video
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [ ] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

## Summary by Sourcery

添加新的今日头条搜索引擎集成，支持多种内容类别，并配置相应的引擎条目。

新功能：
- 引入今日头条搜索引擎实现，将 HTML 响应解析为适用于综合、新闻、视频和图片搜索的 SearXNG 结果类型。
- 在默认配置中注册基于今日头条的综合、新闻、图片和视频引擎，并设置专用快捷方式和类别映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Toutiao search engine integration supporting multiple content categories and configure corresponding engine entries.

New Features:
- Introduce a Toutiao engine implementation that parses HTML responses into SearXNG result types for general, news, video, and image searches.
- Register Toutiao-based general, news, image, and video engines in the default settings with dedicated shortcuts and category mappings.

</details>